### PR TITLE
Document API behind feature flag using `doc(cfg = ..)` attribute.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ left-right = { version = "0.11.0" }
 quickcheck = "0.9"
 quickcheck_macros = "0.9"
 rand = "0.7"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,7 @@
 // This _should_ detect if we ever accidentally leak aliasing::NoDrop.
 // But, currently, it does not..
 #![deny(unreachable_pub)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use crate::inner::Inner;
 use crate::read::ReadHandle;

--- a/src/write.rs
+++ b/src/write.rs
@@ -242,6 +242,7 @@ where
     }
 
     #[cfg(feature = "eviction")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "eviction")))]
     /// Remove the value-bag for `n` randomly chosen keys.
     ///
     /// This method immediately calls [`publish`](Self::publish) to ensure that the keys and values


### PR DESCRIPTION
Following the pattern as can be observed in e.g. the `tokio` crate.

You can compile with
```
cargo +nightly rustdoc --all-features -- --cfg docsrs
```
for testing/building the docsrs-style documentation locally.