### PR TITLE
Follow a clippy hint to use unstable sort in empty_random

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -280,7 +280,7 @@ where
         // we need to sort the indices so that, later, we can make sure to swap remove from last to
         // first (and so not accidentally remove the wrong index).
         let mut to_remove = indices.clone().into_vec();
-        to_remove.sort();
+        to_remove.sort_unstable();
         self.add_op(Operation::EmptyAt(to_remove));
 
         indices.into_iter().map(move |i| {


### PR DESCRIPTION
```
warning: used sort instead of sort_unstable to sort primitive type `usize`
   --> src/write.rs:283:9
    |
283 |         to_remove.sort();
    |         ^^^^^^^^^^^^^^^^ help: try: `to_remove.sort_unstable()`
    |

```

According to the docs “When applicable, unstable sorting is preferred because it is generally faster than stable sorting and it doesn't allocate auxiliary memory.”