### PR TITLE
Implement Serialize for MapReadRef

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ smallvec = "1.0.0"
 hashbag = "0.1.3"
 rand = { version = "0.7", default-features = false, features = ["alloc"], optional = true }
 left-right = { version = "0.11.0" }
+serde = {version = "1.0", optional = true}
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -289,3 +289,36 @@ where
         self.iter.next().map(|(_, v)| v.as_ref())
     }
 }
+
+#[cfg(feature = "serde")]
+impl<T, S> serde::Serialize for Values<T, S>
+where
+    T: serde::Serialize,
+{
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
+    where
+        SER: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for e in self {
+            serde::ser::SerializeSeq::serialize_element(&mut seq, e)?;
+        }
+        serde::ser::SerializeSeq::end(seq)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'rh, K, V, M, S> serde::Serialize for MapReadRef<'rh, K, V, M, S>
+where
+    K: Hash + Eq + serde::Serialize,
+    V: Eq + Hash + serde::Serialize,
+    S: BuildHasher,
+{
+    #[inline]
+    fn serialize<SER>(&self, serializer: SER) -> Result<SER::Ok, SER::Error>
+    where
+        SER: serde::Serializer,
+    {
+        serializer.collect_map(self)
+    }
+}


### PR DESCRIPTION
This solves #2

I tried also implementing `serde::Deserialize` for `(WriteHandle, ReadHandle)` but apparently implementing a foreign trait on a tuple with generic structs violates the orphan rule.

note that this can't be collected into a `Hashmap<K,V>` but into a `HashMap<K, Vec<V>>`