### PR TITLE
Style changes suggested by clippy

### DIFF
--- a/src/values.rs
+++ b/src/values.rs
@@ -36,9 +36,9 @@ where
     Long(hashbag::HashBag<Aliased<T, D>, S>),
 }
 
-impl<T, S> Into<Values<T, S>> for ValuesInner<T, S, crate::aliasing::NoDrop> {
-    fn into(self) -> Values<T, S> {
-        Values(self)
+impl<T, S> From<ValuesInner<T, S, crate::aliasing::NoDrop>> for Values<T, S> {
+    fn from(v: ValuesInner<T, S, crate::aliasing::NoDrop>) -> Self {
+        Values(v)
     }
 }
 
@@ -346,10 +346,7 @@ where
     ) -> Self {
         match &other {
             ValuesInner::Short(s) => {
-                use std::iter::FromIterator;
-                ValuesInner::Short(smallvec::SmallVec::from_iter(
-                    s.iter().map(|v| v.alias().change_drop()),
-                ))
+                ValuesInner::Short(s.iter().map(|v| v.alias().change_drop()).collect())
             }
             ValuesInner::Long(l) => {
                 let mut long = hashbag::HashBag::with_hasher(hasher.clone());


### PR DESCRIPTION
I think these changes are useful
1. From is superior to Into (allows doing `Values::from(inner)` and also doing `inner.into()`)
2. collect is nicer and apparently the official docs discourage using `FromIterator` directly.

Clippy also suggested replacing: 
```rust
&*self.0 as *const _ as *const () == &*other.0 as *const _ as *const ()
```
with:
```rust
std::ptr::eq(&*self.0 as *const _, &*other.0 as *const _)
```

but I don't think it's really any nicer so I didn't include it, but if you prefer I'll include it and add clippy to the CI